### PR TITLE
1.7.1.2 — CVE-2026-32597 security backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   critical extensions instead of rejecting them, enabling split-brain verification
   attacks in mixed-library deployments. https://github.com/advisories/GHSA-752w-5fwx-jx9f
 
-- [CVE-2022-29217] Prevent key confusion through non-blocklisted public key formats
-  (included from v1.7.1.1). https://github.com/jpadilla/pyjwt/security/advisories/GHSA-ffqj-6fqr-9h24
-
 
 [v1.7.1.1][1.7.1.1]
 -------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+[v1.7.1+security.2][1.7.1+security.2]
+-------------------------------------------------------------------------
+
+### Security
+
+- [CVE-2026-32597] Reject JWT tokens containing unknown `crit` (Critical) header
+  extensions per RFC 7515 §4.1.11. PyJWT previously accepted tokens with unknown
+  critical extensions instead of rejecting them, enabling split-brain verification
+  attacks in mixed-library deployments. https://github.com/advisories/GHSA-752w-5fwx-jx9f
+
+- [CVE-2022-29217] Prevent key confusion through non-blocklisted public key formats
+  (included from v1.7.1.1). https://github.com/jpadilla/pyjwt/security/advisories/GHSA-ffqj-6fqr-9h24
+
+
 [v1.7.1.1][1.7.1.1]
 -------------------------------------------------------------------------
 

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -10,7 +10,7 @@ http://self-issued.info/docs/draft-jones-json-web-token-01.html
 
 
 __title__ = 'pyjwt'
-__version__ = '1.7.1.2'
+__version__ = '1.7.1+security.2'
 __author__ = 'José Padilla'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2018 José Padilla'

--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -10,7 +10,7 @@ http://self-issued.info/docs/draft-jones-json-web-token-01.html
 
 
 __title__ = 'pyjwt'
-__version__ = '1.7.1'
+__version__ = '1.7.1.2'
 __author__ = 'José Padilla'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2018 José Padilla'

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -228,6 +228,30 @@ class PyJWS(object):
     def _validate_headers(self, headers):
         if 'kid' in headers:
             self._validate_kid(headers['kid'])
+        if 'crit' in headers:
+            self._validate_crit(headers)
+
+    def _validate_crit(self, headers):
+        # Backport of CVE-2026-32597 (GHSA-752w-5fwx-jx9f):
+        # RFC 7515 §4.1.11 requires that unknown critical extensions MUST
+        # cause the token to be rejected.
+        crit = headers.get('crit')
+        if not isinstance(crit, list) or len(crit) == 0:
+            raise InvalidTokenError('crit header must be a non-empty list')
+        for ext in crit:
+            if ext not in self._valid_crit:
+                raise InvalidTokenError(
+                    'Unsupported critical extension: %s' % ext
+                )
+            if ext not in headers:
+                raise InvalidTokenError(
+                    'Critical extension %s listed in crit but not in header' % ext
+                )
+
+    # Set of critical extensions this implementation understands.
+    # Empty by default — any crit token will be rejected unless an
+    # extension is explicitly added here by a subclass.
+    _valid_crit = set()
 
     def _validate_kid(self, kid):
         if not isinstance(kid, string_types):


### PR DESCRIPTION
Backport CVE-2026-32597 (crit header validation). Built on 1.7.1.1. Tag: 1.7.1.2. Ticket: CS-2178.