### PR TITLE
CS-2178 CVE-2026-32597: wire _validate_headers into decode()

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -10,7 +10,7 @@ http://self-issued.info/docs/draft-jones-json-web-token-01.html
 
 
 __title__ = 'pyjwt'
-__version__ = '1.7.1+security.2'
+__version__ = '1.7.1+security.3'
 __author__ = 'José Padilla'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2018 José Padilla'

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -155,6 +155,8 @@ class PyJWS(object):
             self._verify_signature(payload, signing_input, header, signature,
                                    key, algorithms)
 
+        self._validate_headers(header)
+
         return payload
 
     def get_unverified_header(self, jwt):

--- a/jwt/api_jws.py
+++ b/jwt/api_jws.py
@@ -235,7 +235,7 @@ class PyJWS(object):
 
     def _validate_crit(self, headers):
         # Backport of CVE-2026-32597 (GHSA-752w-5fwx-jx9f):
-        # RFC 7515 §4.1.11 requires that unknown critical extensions MUST
+        # RFC 7515 section 4.1.11 requires that unknown critical extensions MUST
         # cause the token to be rejected.
         crit = headers.get('crit')
         if not isinstance(crit, list) or len(crit) == 0:
@@ -251,7 +251,7 @@ class PyJWS(object):
                 )
 
     # Set of critical extensions this implementation understands.
-    # Empty by default — any crit token will be rejected unless an
+    # Empty by default - any crit token will be rejected unless an
     # extension is explicitly added here by a subclass.
     _valid_crit = set()
 


### PR DESCRIPTION
## Summary

`_validate_crit()` was added in 1.7.1.2 and `_validate_headers()` calls it when a `crit` header is present. However `_validate_headers()` was only wired into `get_unverified_header()`, not into `decode()`. This meant tokens with unknown critical extensions were silently accepted on `jwt.decode()`.

## Change

`jwt/api_jws.py` — adds `self._validate_headers(header)` to `PyJWS.decode()` just before `return payload`:

```diff
+        self._validate_headers(header)
+
         return payload
```

## Test plan

- [x] PoC test `test_cve_2026_32597.py::test_jwt_with_unknown_crit_extension_is_rejected` passes
- [x] Existing regression tests (`test_pyjwt.py`) all pass
- Cut as `1.7.1.4` after merge